### PR TITLE
[FEATURE] add endpoint to retrieve metainf of jobConfirmationPdf record

### DIFF
--- a/src/main/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdf.java
+++ b/src/main/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdf.java
@@ -1,8 +1,12 @@
 package de.steinuntersteinen.jerpapi.jobconfirmation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.data.annotation.Id;
 
 import java.util.UUID;
 
-public record JobConfirmationPdf(@Id UUID id, String filename, byte[] file) {
-}
+public record JobConfirmationPdf(
+        @Id UUID id,
+        String filename,
+        @JsonIgnore  byte[] file
+) {}

--- a/src/main/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdfController.java
+++ b/src/main/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdfController.java
@@ -2,16 +2,15 @@ package de.steinuntersteinen.jerpapi.jobconfirmation;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.UUID;
 
 @RequestMapping("/api/jobconfirmations")
 @RestController
@@ -36,13 +35,22 @@ public class JobConfirmationPdfController {
             return ResponseEntity.badRequest().build();
         }
 
-        JobConfirmationPdf storedJobConfirmationPdf = storageService.store(file);
+        UUID id = storageService.store(file);
         URI locationOfStoredJobConfirmationPdf = ucb
                 .path("/api/confirmations/{id}")
-                .buildAndExpand(storedJobConfirmationPdf.id())
+                .buildAndExpand(id)
                 .toUri();
 
         return ResponseEntity.created(locationOfStoredJobConfirmationPdf).build();
+    }
+
+    @GetMapping("/{id}")
+    private ResponseEntity<JobConfirmationPdf> findJobConfirmationPdfMetadataById(@PathVariable("id") String id) {
+        UUID uuid = UUID.fromString(id);
+        Optional<JobConfirmationPdf> jobConfirmationPdfOptional = storageService.get(uuid);
+        return jobConfirmationPdfOptional
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
 }

--- a/src/main/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdfStorageService.java
+++ b/src/main/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdfStorageService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class JobConfirmationPdfStorageService {
@@ -14,8 +16,16 @@ public class JobConfirmationPdfStorageService {
         this.repo = repo;
     }
 
-    public JobConfirmationPdf store(MultipartFile file) throws IOException {
-        return repo.save(new JobConfirmationPdf(null, file.getOriginalFilename(), file.getBytes()));
+    public UUID store(MultipartFile file) throws IOException {
+        return repo.save(new JobConfirmationPdf(
+                null,
+                file.getOriginalFilename(),
+                file.getBytes()))
+                .id();
+    }
+
+    public Optional<JobConfirmationPdf> get(UUID uuid) {
+        return repo.findById(uuid);
     }
 
 }

--- a/src/test/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationJsonTest.java
+++ b/src/test/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationJsonTest.java
@@ -1,0 +1,57 @@
+package de.steinuntersteinen.jerpapi.jobconfirmation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@JsonTest
+class JobConfirmationJsonTest {
+
+    @Autowired
+    private JacksonTester<JobConfirmationPdf> json;
+
+    @Test
+    void jobConfirmationSerializationTest() throws IOException {
+
+        Path testFile = Paths.get("src/test/resources/dummy.pdf");
+        String testFileName = testFile.getFileName().toString();
+
+        JobConfirmationPdf jobConfirmationPdf = new JobConfirmationPdf(
+                UUID.fromString("a759981c-611e-4367-abcd-9f319b273949"),
+                testFileName,
+                Files.readAllBytes(testFile)
+        );
+
+        assertThat(json.write(jobConfirmationPdf))
+                .isStrictlyEqualToJson("expected.json");
+    }
+
+    @Test
+    void jobConfirmationDeserializationTest() throws IOException {
+        String expected = """
+                {
+                    "id": "a759981c-611e-4367-abcd-9f319b273949",
+                    "filename": "dummy.pdf",
+                    "file": ""
+                }
+                """;
+
+        assertThat(json.parse(expected)).isEqualTo(
+                new JobConfirmationPdf(
+                        UUID.fromString("a759981c-611e-4367-abcd-9f319b273949"),
+                        "dummy.pdf",
+                        null
+                ));
+    }
+
+}

--- a/src/test/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdfControllerTest.java
+++ b/src/test/java/de/steinuntersteinen/jerpapi/jobconfirmation/JobConfirmationPdfControllerTest.java
@@ -1,16 +1,25 @@
 package de.steinuntersteinen.jerpapi.jobconfirmation;
 
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,6 +76,35 @@ class JobConfirmationPdfControllerTest {
 
         mvc.perform(multipart("/api/jobconfirmations/upload").file(mockFile))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnJobConfirmationPdfMetadata(@Autowired JdbcTemplate jdbcTemplate,
+                                                @Autowired TestRestTemplate restTemplate) {
+        JobConfirmationPdf testRecord = new JobConfirmationPdf(
+                UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+                "testfile.pdf",
+                "MockData".getBytes(StandardCharsets.UTF_8)
+        );
+
+        jdbcTemplate.update("""
+                    INSERT INTO job_confirmation_pdf (id, filename, file)
+                    VALUES (?, ?, ?)""",
+                testRecord.id(), testRecord.filename(), testRecord.file()
+        );
+
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "/api/jobconfirmations/123e4567-e89b-12d3-a456-426614174000",
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        DocumentContext documentContext = JsonPath.parse(response.getBody());
+        UUID id = UUID.fromString(documentContext.read("$.id"));
+        assertThat(id).isEqualTo(testRecord.id());
+
+        String filename = documentContext.read("$.filename");
+        assertThat(filename).isEqualTo(testRecord.filename());
     }
 
 }

--- a/src/test/resources/de/steinuntersteinen/jerpapi/jobconfirmation/expected.json
+++ b/src/test/resources/de/steinuntersteinen/jerpapi/jobconfirmation/expected.json
@@ -1,0 +1,4 @@
+{
+  "id": "a759981c-611e-4367-abcd-9f319b273949",
+  "filename": "dummy.pdf"
+}


### PR DESCRIPTION
This adds a minimal REST endpoint to get meta information of stored jobconfirmation pdf. In JobConfirmationPdf record the file field was annotated with @JsonIgnore, so the data is not transfered on every get request. Added get method to JobConfirmationStorageService and changed the return value of store to UUID, which saves traffic.

API Contract:

    Request
    URI: /api/jobconfirmations/{uuid}
    HTTP Verb: GET
    Body: None

    Response:
    HTTP Status:
    200 OK if job confirmation was successfully retrieved
    404 NOT FOUND if the job confirmation cannot be found
    Response Body Type: JSON
    Example Response Body:
    {
    "id": "b894e613-618d-42f0-89f1-067efd29dd46",
    "filename": "dummy.pdf"
    }

Closes #3