### PR TITLE
[ENHANCEMENT] add configuration for h2 testdatabase

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=jerpapi
+
+# H2 Database for Testing
+spring.datasource.url=jdbc:h2:mem:jerp
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true


### PR DESCRIPTION
For testing an h2 inmemory database is set up. For this stage of development, the configuration resides in application.properties. Test infrastructure should be configured independently when the project gains complexity.